### PR TITLE
Add features on Home Assistant Script

### DIFF
--- a/Python/Raspberry_Pi/Home_Assistant.py
+++ b/Python/Raspberry_Pi/Home_Assistant.py
@@ -17,6 +17,7 @@
 #  https://github.com/metriful/sensor
 
 import requests
+import logging
 from sensor_package.sensor_functions import *
 
 #########################################################
@@ -32,17 +33,29 @@ cycle_period = CYCLE_PERIOD_100_S
 
 # Choose a unique name for this MS430 sensor board so you can identify it.
 # Variables in HA will have names like: SENSOR_NAME.temperature, etc.
-SENSOR_NAME = "kitchen3"
+SENSOR_NAME = "ms430"
 
-# Specify the IP address of the computer running Home Assistant. 
-# You can find this from the admin interface of your router.
-HOME_ASSISTANT_IP = "192.168.43.144"
+# Specify the URL of the Home Assistant instance. 
+HOME_ASSISTANT_URL = "http://192.168.43.144:8123"
+# Set to false for unverified SSL connections
+HOME_ASSISTANT_SSL_VERIFY = True
 
 # Security access token: the Readme and User Guide explain how to get this
-LONG_LIVED_ACCESS_TOKEN = "PASTE YOUR TOKEN HERE WITHIN QUOTES"
+LONG_LIVED_ACCESS_TOKEN = ""
+
+#Valid logging levels defined at https://docs.python.org/3/library/logging.html#levels
+LOG_LEVEL="ERROR"
 
 # END OF USER-EDITABLE SETTINGS
 #########################################################
+
+logger = logging.getLogger()
+logger.setLevel(LOG_LEVEL.upper())
+log_format = logging.Formatter(
+    '%(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+consolelog = logging.StreamHandler()
+consolelog.setFormatter(log_format)
+logger.addHandler(consolelog)
 
 # Set up the GPIO and I2C communications bus
 (GPIO, I2C_bus) = SensorHardwareSetup()
@@ -53,23 +66,28 @@ I2C_bus.write_i2c_block_data(i2c_7bit_address, CYCLE_TIME_PERIOD_REG, [cycle_per
 
 #########################################################
 
-print("Reporting data to Home Assistant. Press ctrl-c to exit.")
+logging.info("Reporting data to Home Assistant. Press ctrl-c to exit.")
 
 # Enter cycle mode
 I2C_bus.write_byte(i2c_7bit_address, CYCLE_MODE_CMD)
 
 while (True):
-
   # Wait for the next new data release, indicated by a falling edge on READY
   while (not GPIO.event_detected(READY_pin)):
     sleep(0.05)
   
-  # Now read all data from the MS430
-  air_data = get_air_data(I2C_bus)
-  air_quality_data = get_air_quality_data(I2C_bus)
-  light_data = get_light_data(I2C_bus)
-  sound_data = get_sound_data(I2C_bus)
-  particle_data = get_particle_data(I2C_bus, PARTICLE_SENSOR)
+  try:
+    logging.info("Starting uploading cycle")
+    # Now read all data from the MS430
+    air_data = get_air_data(I2C_bus)
+    air_quality_data = get_air_quality_data(I2C_bus)
+    light_data = get_light_data(I2C_bus)
+    sound_data = get_sound_data(I2C_bus)
+    particle_data = get_particle_data(I2C_bus, PARTICLE_SENSOR)
+  except Exception as e:
+    logging.error("Error getting data from sensor...")
+    logging.debug(repr(e))
+    logging.info("The program will continue and retry on the next data output.")
   
   # Specify information needed by Home Assistant.
   # Icons are chosen from https://cdn.materialdesignicons.com/5.3.45/    
@@ -97,23 +115,24 @@ while (True):
     variables.append(particle)
   try:
     for v in variables:
-      url = ("http://" + HOME_ASSISTANT_IP + ":8123/api/states/" + 
-            SENSOR_NAME + "." + v['name'].replace(' ','_'))
+      url = (HOME_ASSISTANT_URL + "/api/states/" + 
+            "sensor." + SENSOR_NAME + "_" + v['name'].replace(' ','_').lower())
       head = {"Content-type": "application/json","Authorization": "Bearer " + LONG_LIVED_ACCESS_TOKEN}
       try:
         valueStr = "{:.{dps}f}".format(v['data'], dps=v['decimals'])
       except:
         valueStr = v['data']
-      payload = {"state":valueStr, "attributes":{"unit_of_measurement":v['unit'],
+      payload = {"state":valueStr, "attributes":{"unique_id":SENSOR_NAME, "unit_of_measurement":v['unit'],
                  "friendly_name":v['name'], "icon":"mdi:" + v['icon']}}
-      requests.post(url, json=payload, headers=head, timeout=2)
+      logging.debug("Info uploaded: %s" % payload)
+      request = requests.post(url, json=payload, headers=head, timeout=2, verify=HOME_ASSISTANT_SSL_VERIFY)
   except Exception as e:
     # An error has occurred, likely due to a lost network connection, 
     # and the post has failed.
     # The program will retry with the next data release and will succeed 
     # if the network reconnects.
-    print("HTTP POST failed with the following error:")
-    print(repr(e))
-    print("The program will continue and retry on the next data output.")
-
+    logging.error("HTTP(S) POST failed with the following error:")
+    logging.debug(repr(e))
+    logging.info("The program will continue and retry on the next data output.")
+  logging.info("Waiting until next cycle")
 


### PR DESCRIPTION
Bugfixes:
- Allow home assistant instances on different port than 8123
- allow home assistant instances with SSL access (SSL connections verified or not)
- capture exceptions on getting data from i2c bus
- entities (states) are created under the "sensor" integration, to allow Home Assistant to gauge them

Functionalities:
- entities grouped under the same unique_id
- use logging module instead of print to allow logging level selection and logging on journal when daemonized